### PR TITLE
feat: add column letter before the result number for clearer view on the bingo

### DIFF
--- a/index.php
+++ b/index.php
@@ -26,7 +26,7 @@
                         <button class="btn btn-danger btn-lg"><i class="fas fa-stop"></i> Stop</button>
                         <button class="btn btn-secondary btn-lg"><i class="fas fa-sync"></i> Refresh</button>
                     </div>
-                    <div id="results" class="mt-4 p-4"></div>
+                    <div id="results" class="mt-4 p-3"></div>
                 </div>
                 <div class="col-8">
                     <table class="table table-bordered text-center mr-5">

--- a/script.js
+++ b/script.js
@@ -5,6 +5,16 @@ for (let i = 1; i <= 75; i++) {
     cardNumIn.push(i);
 }
 
+// Function to get the column letter for a given number
+function getColumnLetter(num) {
+    if (num >= 1 && num <= 15) return 'J';
+    if (num >= 16 && num <= 30) return 'I';
+    if (num >= 31 && num <= 45) return 'N';
+    if (num >= 46 && num <= 60) return 'G';
+    if (num >= 61 && num <= 75) return 'O';
+    return '';
+}
+
 $(function () {
     window.setInterval(function () {
         if (runDraw) {
@@ -58,9 +68,14 @@ function drawNum() {
 
     cardNumOut.push(randomCarNum);
     removeNum(randomCarNum);
-    $('#ball').text(randomCarNum);
+
+    // Get the column letter and format the display
+    let columnLetter = getColumnLetter(randomCarNum);
+    let displayText = columnLetter + ' - ' + randomCarNum;
+
+    $('#ball').text(displayText);
     $('#card-num-' + randomCarNum).addClass('bg-info').addClass('text-white');
-    $('#results').append('<button class="btn btn-light btn-lg d-flex justify-content-center align-items-center result-wh mr-2 mb-2 shadow-sm">' + randomCarNum + '</button> ');
+    $('#results').append('<button class="btn btn-light btn-lg d-flex justify-content-center align-items-center result-wh mr-2 mb-2 shadow-sm">' + displayText + '</button> ');
     $('#results button:last-child').focus();
 }
 

--- a/style.css
+++ b/style.css
@@ -3,6 +3,6 @@
     flex-wrap: wrap;
 }
 .result-wh{
-    width: 57px;
+    width: 95px;
     height: 48px;
 }


### PR DESCRIPTION
Added a getColumnLetter() function that maps each number to its corresponding BINGO column:
- J: numbers 1-15
- I: numbers 16-30
- N: numbers 31-45
- G: numbers 46-60
- O: numbers 61-75


Updated the drawNum() function to format the display as "LETTER - NUMBER" (e.g., "J - 1", "O - 75", etc.)

Modified both display locations:
- The main ball display (#ball) now shows the formatted text
- The results buttons also show the column letter with the number

Now when you draw numbers, they will appear as:
- "J - 5" instead of just "5"
- "I - 23" instead of just "23"
- "N - 42" instead of just "42"
- And so on...

The game will continue to work exactly as before, but now players can clearly see which BINGO column each called number belongs to, making it easier to mark their cards correctly!